### PR TITLE
Github Intergration and !verison command

### DIFF
--- a/bot/controllers/release.js
+++ b/bot/controllers/release.js
@@ -26,7 +26,7 @@ class ReleaseController extends BaseController {
   }
 
   ReleaseAction() {
-    // Post Max Bot's Current Version Number
+    // Post Max Bot's Current Version Number from the Package.json version
     return `My Current Version is ${this.pjson.version}`;
   }
 }

--- a/bot/controllers/release.js
+++ b/bot/controllers/release.js
@@ -1,0 +1,33 @@
+const BaseController = require('../baseController.js');
+const Command = require('../baseCommand.js');
+
+// Import Package.json
+const pjson = require('../../package.json');
+
+class ReleaseController extends BaseController {
+  constructor(message) {
+    // Call BaseController constructor
+    super(message);
+
+    // Aliasing 'this' as controller to allow for binding in actions
+    const controller = this;
+    this.pjson = pjson;
+
+    // Array of all commands, see baseCommand.js for prototype
+    this.commands = [
+      new Command(
+        '!version',
+        '!version',
+        'Max Bot\'s Current Version Number',
+        'Post Max Bot\'s Current Version Number in Current Channel',
+        this.ReleaseAction.bind(controller),
+      ),
+    ];
+  }
+
+  ReleaseAction() {
+    // Post Max Bot's Current Version Number
+    return `My Current Version is ${this.pjson.version}`;
+  }
+}
+module.exports = ReleaseController;


### PR DESCRIPTION
This feature alone adds the !version command to display the current version of Max Bot in a text channel. This part of the functionality is done by reading the current version number in the codebase.

Along with the new command, I figured out to get Discord's integrated GitHub Bot to join the server and send live updates from the repository. Since I learned adding this feature to Max Bot is outside the scope, the following is a guide on how to get the GitHub Bot Working on your test server.

1. Fork Max-Bot so you have access to Github's Webhooks
2. Open your Discord server settings and navigate to the "Webhooks" tab.
3. Create a new Webhook and select the #textchannel you want the bot to post in.
4. Navigate to your forked Max-Bot Repo, go into settings and add a Webhook.
5. Copy the Webhook URL from Discord and use it as the PayLoad URL with the following format: ```DISCORD_WEBHOOOK_URL/github```
6. Select what events you want the bot to get trigged on (Releases, Tags, Commits, etc..).
7. Trigger a seleted event and check the selected text channel in Discord.

If you are unable to get the Github Integration working properally please tell me in the reviews and I'll try and help with your issue.